### PR TITLE
Directly send wormholes off to the server

### DIFF
--- a/autoPlay.user.js
+++ b/autoPlay.user.js
@@ -1757,7 +1757,12 @@ function tryUsingAbility(itemId, checkInLane, forceAbility) {
 }
 
 function triggerAbility(abilityId) {
-	s().m_rgAbilityQueue.push({'ability': abilityId});
+	if (abilityId === ABILITIES.WORMHOLE) {
+		// Fire this bad boy off immediately
+		g_Server.UseAbilities($J.noop, $J.noop, {requested_abilities: [{ability: ABILITIES.WORMHOLE}]})
+	} else {
+		s().m_rgAbilityQueue.push({'ability': abilityId});
+	}
 
 	var nCooldownDuration = s().m_rgTuningData.abilities[abilityId].cooldown;
 	s().ClientOverride('ability', abilityId, Math.floor(Date.now() / 1000) + nCooldownDuration);


### PR DESCRIPTION
This means requests will actually be sent as fast as the setInterval is, as opposed to buffered client-side for the next second like they are now.